### PR TITLE
Backwards compatibility for older python3 versions

### DIFF
--- a/recollapse
+++ b/recollapse
@@ -39,8 +39,8 @@ class Recollapse:
                  encoding: int,
                  range: list,
                  positions: list,
-                 input: Optional[None],
-                 file: Optional[None],
+                 input: Optional[str],
+                 file: Optional[str],
                  normtable: bool,
                  alphanum: bool,
                  maxnorm: int) -> None:

--- a/recollapse
+++ b/recollapse
@@ -7,7 +7,7 @@ import string
 import sys
 import urllib.parse
 import warnings
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 import unidecode
 from prettytable import PrettyTable
@@ -39,8 +39,8 @@ class Recollapse:
                  encoding: int,
                  range: list,
                  positions: list,
-                 input: str | None,
-                 file: str | None,
+                 input: Optional[None],
+                 file: Optional[None],
                  normtable: bool,
                  alphanum: bool,
                  maxnorm: int) -> None:


### PR DESCRIPTION
If we use `str | None` in python3.9 or older, there'll be an error. 
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/47a2e38d-e012-4d57-b9e6-981c2f9ebe49" />