### PR TITLE
Updated recollapse with options for unicode casing and byte truncation

### DIFF
--- a/recollapse
+++ b/recollapse
@@ -5,6 +5,7 @@ import contextlib
 import itertools
 import string
 import sys
+import unicodedata
 import urllib.parse
 import warnings
 from typing import ClassVar, Optional
@@ -15,7 +16,7 @@ from prettytable import PrettyTable
 warnings.simplefilter("ignore")
 
 
-VERSION = 0.4
+VERSION = 0.5
 
 
 class Recollapse:
@@ -29,11 +30,15 @@ class Recollapse:
     MODE_NORM = 3
     MODE_TERM = 4
     MODE_RE_META = 5
+    MODE_CASE = 6
+    MODE_TRUNC = 7
 
     REGEX_METACHARS = ".^$*+-?()[]{}\\|"
 
     output: ClassVar[list] = []
     normalization_d: ClassVar[dict] = {}
+    truncation_d: ClassVar[dict] = {}
+    case_mapping_d: ClassVar[dict] = {}
 
     def __init__(self, size: int,
                  encoding: int,
@@ -44,7 +49,6 @@ class Recollapse:
                  normtable: bool,
                  alphanum: bool,
                  maxnorm: int) -> None:
-        self.build_normalization_dict()
         self.size = size
         self.encoding = encoding
         self.range = range
@@ -54,6 +58,10 @@ class Recollapse:
         self.normtable = normtable
         self.alphanum = alphanum
         self.maxnorm = maxnorm
+        self.build_normalization_dict()
+        self.build_truncation_dict()
+        self.build_case_mapping_dict()
+
 
     def run(self) -> None:
         if self.normtable:
@@ -103,6 +111,20 @@ class Recollapse:
                     if c in self.REGEX_METACHARS:
                         for t in itertools.product(fuzzing_range, repeat=self.size):
                             self.generate(t, i, replace=True)
+            
+            if self.MODE_CASE in self.positions:
+                for i in range(len(self.current_input)):
+                    c = self.current_input[i]
+                    if c in self.case_mapping_d:
+                        for cc in self.case_mapping_d.get(c):
+                            self.generate((ord(cc),), i, replace=True)
+            
+            if self.MODE_TRUNC in self.positions:
+                for i in range(len(self.current_input)):
+                    c = self.current_input[i]
+                    if c in self.truncation_d:
+                        for cc in self.truncation_d.get(c):
+                            self.generate((ord(cc),), i, replace=True)
 
         print("\n".join(sorted(set(self.output))))
 
@@ -133,6 +155,47 @@ class Recollapse:
         tab.border = False
         tab.add_rows(table)
         print(tab)
+
+
+    def build_truncation_dict(self):
+        for c in range(0x110000):
+            if 0xD800 <= c <= 0xDFFF:
+                continue  # Skip surrogate pairs
+            low_byte = c & 0xFF
+            if 0x20 <= low_byte <= 0x7E:
+                try:
+                    ascii_char = chr(low_byte)
+                    if ascii_char not in self.truncation_d:
+                        self.truncation_d[ascii_char] = []
+                    if chr(c) not in self.truncation_d[ascii_char] and chr(c) != ascii_char:
+                        self.truncation_d[ascii_char].append(chr(c))
+                except:
+                    continue
+    
+
+    def print_truncation_table(self):
+        self.print_table(self.truncation_d)
+
+
+    def build_case_mapping_dict(self):
+        for c in range(0x110000):
+            if 0xD800 <= c <= 0xDFFF:
+                continue
+            char = chr(c)
+            for transformed in [char.upper(), char.lower(), char.casefold()]:
+                if (
+                    len(transformed) < 2 and
+                    0x20 <= ord(transformed) <= 0x7E
+                ):
+                    ascii_char = transformed
+                    if ascii_char not in self.case_mapping_d:
+                        self.case_mapping_d[ascii_char] = []
+                    if char not in self.case_mapping_d[ascii_char] and char != ascii_char:
+                        self.case_mapping_d[ascii_char].append(char)
+
+
+    def print_case_mapping_table(self):
+        self.print_table(self.case_mapping_d)
 
 
     def generate(self, bytes, index, replace=False) -> None:
@@ -175,7 +238,7 @@ class Recollapse:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="REcollapse is a helper tool for black-box regex fuzzing to bypass validations and discover normalizations in web applications")
 
-    parser.add_argument("-p", "--positions", help="pivot position modes. Example: 1,2,3,4,5 (default). 1: starting, 2: separator, 3: normalization, 4: termination, 5: regex metacharacters", required=False, default="1,2,3,4,5", type=str)
+    parser.add_argument("-p", "--positions", help="pivot position modes. Example: 1,2,3,4,5,6 (default). 1: starting, 2: separator, 3: normalization, 4: termination, 5: regex metacharacters, 6: case folding/upper/lower, 7: truncation (heavy)", required=False, default="1,2,3,4,5,6", type=str)
     parser.add_argument("-e", "--encoding", help="1: URL-encoded format (default), 2: Unicode format, 3: Raw format, 4: Double URL-encoded format", required=False, default=1, type=int, choices=range(1, 5))
     parser.add_argument("-r", "--range", help="range of bytes for fuzzing. Example: 0,0xff (default)", required=False, default="0,0xff", type=str)
     parser.add_argument("-s", "--size", help="number of fuzzing bytes (default: 1)", required=False, default=1)
@@ -212,12 +275,12 @@ def parse_args() -> argparse.Namespace:
             sys.exit(1)
 
         for p in args.positions:
-            if not 0 < p <= 5:
+            if not 0 < p <= 7:
                 print("Invalid positions provided")
                 sys.exit(1)
 
     args.size = int(args.size)
-    
+
     if not args.input and not args.file and not args.normtable:
         if not sys.stdin.isatty():
             args.input = sys.stdin.read().rstrip()
@@ -236,3 +299,4 @@ def run_recollapse(args: argparse.Namespace) -> None:
 if __name__ == "__main__":
     args = parse_args()
     run_recollapse(args)
+


### PR DESCRIPTION
New position options (6 and 7) for unicode casing and byte trunction.
```
$ ./recollapse -h
usage: recollapse [-h] [-p POSITIONS] [-e {1,2,3,4}] [-r RANGE] [-s SIZE] [-f FILE] [-an] [-mn MAXNORM] [-nt] [--version] [input]

REcollapse is a helper tool for black-box regex fuzzing to bypass validations and discover normalizations in web applications

positional arguments:
  input                 original input

options:
  -h, --help            show this help message and exit
  -p POSITIONS, --positions POSITIONS
                        pivot position modes. Example: 1,2,3,4,5,6 (default). 1: starting, 2: separator, 3: normalization, 4: termination, 5: regex metacharacters, 6:
                        case folding/upper/lower, 7: truncation (heavy)
  -e {1,2,3,4}, --encoding {1,2,3,4}
                        1: URL-encoded format (default), 2: Unicode format, 3: Raw format, 4: Double URL-encoded format
  -r RANGE, --range RANGE
                        range of bytes for fuzzing. Example: 0,0xff (default)
  -s SIZE, --size SIZE  number of fuzzing bytes (default: 1)
  -f FILE, --file FILE  read input from file
  -an, --alphanum       include alphanumeric bytes in fuzzing range
  -mn MAXNORM, --maxnorm MAXNORM
                        maximum number of normalizations (default: 3)
  -nt, --normtable      print normalization table
  --version             show recollapse version
```

Example 1 - to look for a unicode character that will turn into an ascii captital I with casing changes - 
```
$ ./recollapse -p 6 "I"
%69
%C4%B1
```
Example 2 - to look for unicode characters that will become an ascii "<" char if there is byte truncation -
```
$ ./recollapse -p 7 "<" | head
%C4%BC
%C8%BC
%CC%BC
%D0%BC
%D4%BC
%D8%BC
%DC%BC
%E0%A0%BC
%E0%A4%BC
%E0%A8%BC
```
